### PR TITLE
Validate AND/OR opcode meaning on device

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -146,8 +146,8 @@ The specific bits waited for seem slightly out of line with what's documented in
 ### `0x08` *Unknown, possibly unused*
 ### `0x09` *Unknown, possibly unused*
 
-### `0x0A` AND Two Registers and an Immediate
-`AND` two registers (one of which is the destination register) and a bitmask together. The second register is given in the 16-bit immediate.
+### `0x0A` AND Registers and an Immediate
+`AND` a source register and a value together, saving the result in the destination register. The source register is given in the 16-bit immediate.
 
 For example:
 ```
@@ -156,7 +156,7 @@ For example:
 
 could mean:
 ```
-r6 = r6 & r7 & 0xFFFFFF00
+r6 = r7 & 0xFFFFFF00
 ```
 Sometimes there are `AND`s with a null bitmask `0x00000000`. It's unclear if that means the bitmask is disabled in this case (then why wouldn't you just set the bitmask to `0xFFFFFFFF`) or that's intentional for setting the destination to zero (but then why not just write a zero immediate?). It's weird, so I'm not so sure about this one.
 

--- a/Documentation.md
+++ b/Documentation.md
@@ -160,8 +160,8 @@ r6 = r6 & r7 & 0xFFFFFF00
 ```
 Sometimes there are `AND`s with a null bitmask `0x00000000`. It's unclear if that means the bitmask is disabled in this case (then why wouldn't you just set the bitmask to `0xFFFFFFFF`) or that's intentional for setting the destination to zero (but then why not just write a zero immediate?). It's weird, so I'm not so sure about this one.
 
-### `0x0B` OR Two Registers and an Immediate
-`OR` two registers (one of which is the destination register) and a bitmask together. The second register is given in the 16-bit immediate.
+### `0x0B` OR Register and an Immediate
+`OR` a source register and a value together, saving the result in the destination register. The source register is given in the 16-bit immediate.
 
 For example:
 ```
@@ -170,9 +170,8 @@ For example:
 
 seems to mean:
 ```
-r6 = r6 | r7 | 0xFFFFFF00
+r6 = r7 | 0xFFFFFF00
 ```
-This one makes sense to have two different registers and a null bitmask, or the same register twice and a non-null bitmask. I haven't seen a case where the registers are the same and the bitmask is null, as that would just be a noop.
 
 ### `0x0C` Add a Register and an Immediate 
 Adds the 32-bit immediate to the content stored in the register referenced by the 16-bit immediate and stores it in the register given in the 8-bit immediate.

--- a/s5l8702_explainer.c
+++ b/s5l8702_explainer.c
@@ -170,7 +170,7 @@ void explain_instruction(uint32_t address) {
         printf("wait for flash ready on FMCSTAT[%d]", cmd.arg1);
         break;
     case 0x0A:
-        printf("and r%d = r%d & r%d & 0x%.8X", cmd.arg1, cmd.arg1, cmd.arg2, cmd.imm);
+        printf("and r%d = r%d & 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
         break;
     case 0x0B:
         printf("or r%d = r%d | 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);

--- a/s5l8702_explainer.c
+++ b/s5l8702_explainer.c
@@ -173,7 +173,7 @@ void explain_instruction(uint32_t address) {
         printf("and r%d = r%d & r%d & 0x%.8X", cmd.arg1, cmd.arg1, cmd.arg2, cmd.imm);
         break;
     case 0x0B:
-        printf("or r%d = r%d | r%d | 0x%.8X", cmd.arg1, cmd.arg1, cmd.arg2, cmd.imm);
+        printf("or r%d = r%d | 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
         break;
     case 0x0C:
         printf("add r%d = r%d + %d", cmd.arg2, cmd.arg1, cmd.imm);


### PR DESCRIPTION
This corrects the meaning of AND/OR to match the observed behaviour of the FMISS on the N5G.

See commit messages for proof.