### PR TITLE
 Validate JZ/JNZ opcode meaning on device

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -260,12 +260,17 @@ r3 = r2 >> 1
 There are cases where the shift value is zero, which would make this just an assignment which makes no sense. It's also unclear if this is a logical shift or an arithmatic shift.
 
 
-### `0x17` Some kind of jump *(unconfirmed)*
-Based on how it looks the same as the other jump instruction, this one is probably some kind of jump too. But I've tested the basics (`jeq`, `jgt`, `jlt`, etc.) and I cant quite figure out what this one does. Maybe it's some kind of "jump if zero" but that has yet to be tested.
+### `0x17` Jump If Zero
+If a register equals zero, then jump to the address given by the 32-bit immediate. The jump is absolute, meaning it's relative to the beginning of the bytecode, not relative to the instruction.
 
 For example:
 ```
-0x17040002000008F0
+0x17040000000008F0
+```
+
+seems to mean:
+```
+if r4 == 0, jump to 0x000008F0
 ```
 
 ### `0x18` *Used, Not yet investigated*

--- a/Documentation.md
+++ b/Documentation.md
@@ -200,17 +200,17 @@ seems to mean:
 r1 = r2 - 4
 ```
 
-### `0x0E` Jump If Not Equal
-If a register does not equal the 16-bit immediate, then jump to the address given by the 32-bit immediate. The jump is absolute, meaning it's relative to the beginning of the bytecode, not relative to the instruction.
+### `0x0E` Jump If Not Zero
+If a register does not equal zero, then jump to the address given by the 32-bit immediate. The jump is absolute, meaning it's relative to the beginning of the bytecode, not relative to the instruction.
 
 For example:
 ```
-0x0E040002000008F0
+0x0E040000000008F0
 ```
 
 seems to mean:
 ```
-if r4 != 2, jump to 0x000008F0
+if r4 != 0, jump to 0x000008F0
 ```
 
 ### `0x0F` *Unknown, possibly unused*

--- a/s5l8702_explainer.c
+++ b/s5l8702_explainer.c
@@ -182,7 +182,7 @@ void explain_instruction(uint32_t address) {
         printf("subtract r%d = r%d - %d", cmd.arg2, cmd.arg1, cmd.imm);
         break;
     case 0x0E:
-        printf("if r%d != %d, jump to 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
+        printf("if r%d != 0, jump to 0x%.8X", cmd.arg1, cmd.imm);
         break;
     case 0x11:
         printf("store *r%d = r%d", cmd.arg2, cmd.arg1);

--- a/s5l8702_explainer.c
+++ b/s5l8702_explainer.c
@@ -109,7 +109,7 @@ char* describe_register(uint32_t offset) {
 }
 
 // List of operations confirmed in testing won't be marked with a '?'
-const char knownInstructions[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x11, 0x13, 0x14};
+const char knownInstructions[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x11, 0x13, 0x14, 0x17};
 uint32_t known = 0;
 
 void explain_instruction(uint32_t address) {
@@ -194,7 +194,7 @@ void explain_instruction(uint32_t address) {
         printf("rshift r%d = r%d >> %d", cmd.arg1, cmd.arg2, cmd.imm);
         break;
     case 0x17:
-        printf("some kind of jump to 0x%.8X based on r%d", cmd.imm, cmd.arg1);
+        printf("if r%d == 0, jump to 0x%.8X", cmd.arg1, cmd.imm);
         break;
     default:
         printf("unknown %.2X", cmd.op);


### PR DESCRIPTION
This corrects the meaning of JZ/JNZ to match the observed behaviour of the FMISS on the N5G.

See commit messages for proof.
