### PR TITLE
Fix up AND/OR semantics with Imm32==0

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -177,9 +177,27 @@ could mean:
 ```
 r6 = r7 & 0xFFFFFF00
 ```
-Sometimes there are `AND`s with a null bitmask `0x00000000`. It's unclear if that means the bitmask is disabled in this case (then why wouldn't you just set the bitmask to `0xFFFFFFFF`) or that's intentional for setting the destination to zero (but then why not just write a zero immediate?). It's weird, so I'm not so sure about this one.
 
 ### `0x0B` OR Register and an Immediate
+
+This instruction has two forms:
+
+#### Immediate == 0
+
+`OR` the destinations register with a source register, saving the result in the destination register. The source register is given in the 16-bit immediate.
+
+For example:
+```
+0x0B06000700000000
+```
+
+seems to mean:
+```
+r6 = r6 | r7
+```
+
+#### Immediate != 0
+
 `OR` a source register and a value together, saving the result in the destination register. The source register is given in the 16-bit immediate.
 
 For example:

--- a/Documentation.md
+++ b/Documentation.md
@@ -147,6 +147,25 @@ The specific bits waited for seem slightly out of line with what's documented in
 ### `0x09` *Unknown, possibly unused*
 
 ### `0x0A` AND Registers and an Immediate
+
+This instruction has two forms:
+
+#### Immediate == 0
+
+`AND` the destination register with a source register, saving the result in the destination register. The source register is given in the 16-bit immediate.
+
+For example:
+```
+0x0A06000700000000
+```
+
+could mean:
+```
+r6 = r6 & r7
+```
+
+#### Immediate != 0
+
 `AND` a source register and a value together, saving the result in the destination register. The source register is given in the 16-bit immediate.
 
 For example:

--- a/s5l8702_explainer.c
+++ b/s5l8702_explainer.c
@@ -170,7 +170,10 @@ void explain_instruction(uint32_t address) {
         printf("wait for flash ready on FMCSTAT[%d]", cmd.arg1);
         break;
     case 0x0A:
-        printf("and r%d = r%d & 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
+        if (cmd.imm == 0)
+            printf("and r%d = r%d & r%d", cmd.arg1, cmd.arg1, cmd.arg2);
+        else
+            printf("and r%d = r%d & 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
         break;
     case 0x0B:
         printf("or r%d = r%d | 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);

--- a/s5l8702_explainer.c
+++ b/s5l8702_explainer.c
@@ -176,7 +176,10 @@ void explain_instruction(uint32_t address) {
             printf("and r%d = r%d & 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
         break;
     case 0x0B:
-        printf("or r%d = r%d | 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
+        if (cmd.imm == 0)
+            printf("or r%d = r%d | r%d", cmd.arg1, cmd.arg1, cmd.arg2);
+        else
+            printf("or r%d = r%d | 0x%.8X", cmd.arg1, cmd.arg2, cmd.imm);
         break;
     case 0x0C:
         printf("add r%d = r%d + %d", cmd.arg2, cmd.arg1, cmd.imm);


### PR DESCRIPTION
This comes from some more fuzzing.

As usual, proofs are in the commit messages.